### PR TITLE
Share states between all clients

### DIFF
--- a/client-script.go
+++ b/client-script.go
@@ -75,7 +75,7 @@ RelayRConnection = (function() {
 			},
 			send: function(data) {
 				var s = this;
-				web.p(route + '/call?connectionId=' + transport.ConnectionId + '&_=' + new Date().getTime(), data, null, "json", null); 
+				web.p(route + '/call?connectionId=' + transport.ConnectionId + '&_=' + new Date().getTime(), data, null, "json", null);
 			}
 		}
 	};
@@ -120,8 +120,8 @@ RelayRConnection = (function() {
 					if (xd.readyState === 4) {
 						if (xd.status === 200) {
 							c(xd);
-						} 
-					} 
+						}
+					}
 				};
 
 				xd.send();
@@ -141,7 +141,7 @@ RelayRConnection = (function() {
 								c(xd);
 							}
 						}
-					} 
+					}
 				};
 
 				xd.onerror = function() {
@@ -206,8 +206,10 @@ RelayRConnection = (function() {
 	return {
 		ready: function(r) {
 			RelayRConnection.r = r;
-
 			web.n();
+		},
+		connectionId:function(){
+			return transport.ConnectionId;
 		},
 		callServer: function(r, f, a) {
 			transport[web.t()].send(JSON.stringify({ S: true, C: transport.ConnectionId, R: r, M: f, A: a}));

--- a/clientOps.go
+++ b/clientOps.go
@@ -5,6 +5,7 @@ package relayr
 type ClientOperations struct {
 	e     *Exchange
 	relay *Relay
+	cid   string
 }
 
 // All invokes a client side method on all clients for the
@@ -16,5 +17,5 @@ func (c *ClientOperations) All(fn string, args ...interface{}) {
 // Others invokes a client side method on all clients except the
 // one who calls it.
 func (c *ClientOperations) Others(fn string, args ...interface{}) {
-	c.e.callGroupMethodExcept(c.relay, "Global", fn, args...)
+	c.e.callGroupMethodExcept(c.relay, "Global", c.cid, fn, args...)
 }

--- a/examples/shareEdit/index.html
+++ b/examples/shareEdit/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Share Edit</title>
+	<script src="/relayr"></script>
+	<script type="text/javascript">
+		RelayRConnection.ready(function() {
+			RelayR.shareEdit.client.updateValue = function(val) {
+				document.getElementById('val').innerHTML = val;
+			};
+			RelayRConnection.callServer("shareEdit","Get",new Array(RelayRConnection.connectionId()));
+			//RelayR.shareEdit.server.get(RelayRConnection.connectionId());
+		});
+	</script>
+	<script type="text/javascript">
+		function doIt(){
+
+			var radioList = document.getElementsByName("operation");
+			var operation;
+			var i = 0;
+			for (i = 0; i < radioList.length; i++){
+				if (radioList[i].checked){
+					operation = radioList[i].value;
+					break;
+				}
+			}
+
+			var val = document.getElementById("number").value;
+
+			if (operation == "add"){
+				RelayR.shareEdit.server.add(val);
+			}else if (operation == "del"){
+				RelayR.shareEdit.server.del(val);
+			}
+		}
+	</script>
+</head>
+<body>
+	<form>
+		<div id="val">0</div><p>
+		<input type="radio" name="operation" id="operation" value="add" checked>Add</input>
+		<input type="radio" name="operation" id="operation" value="del">Del</input>
+		<input type="text" id="number" maxlength="10" size="15" value="5"></input>
+		<input type="button" value="Execute" onclick="doIt();">
+	</form>
+</body>
+</html>

--- a/examples/shareEdit/shareEdit.go
+++ b/examples/shareEdit/shareEdit.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/simon-whitehead/relayr"
+)
+
+type shareEdit struct {
+	val int64
+}
+
+func (this *shareEdit) Get(relay *relayr.Relay, cid string) {
+	relay.CallClient(cid, "updateValue", fmt.Sprint(this.val))
+}
+
+func (this *shareEdit) Add(relay *relayr.Relay, valstr string) {
+	if val, err := strconv.ParseInt(valstr, 10, 64); err == nil {
+		this.val += val
+		relay.Clients.All("updateValue", fmt.Sprint(this.val))
+	}
+}
+
+func (this *shareEdit) Del(relay *relayr.Relay, valstr string) {
+	if val, err := strconv.ParseInt(valstr, 10, 64); err == nil {
+		this.val -= val
+		relay.Clients.All("updateValue", fmt.Sprint(this.val))
+	}
+}
+
+func main() {
+	exchange := relayr.NewExchange()
+	exchange.RegisterRelay(&shareEdit{})
+
+	http.Handle("/relayr/", exchange)
+	http.Handle("/", http.FileServer(http.Dir(".")))
+	http.ListenAndServe(":8080", nil)
+}

--- a/longpoll-transport.go
+++ b/longpoll-transport.go
@@ -58,7 +58,7 @@ func newLongPollTransport(e *Exchange) *longPollTransport {
 	return lp
 }
 
-func (t *longPollTransport) CallClientFunction(relay *Relay, fn string, args ...interface{}) {
+func (t *longPollTransport) CallClientFunction(relay *Relay, cid, fn string, args ...interface{}) {
 	buff := &bytes.Buffer{}
 	encoder := json.NewEncoder(buff)
 
@@ -72,7 +72,7 @@ func (t *longPollTransport) CallClientFunction(relay *Relay, fn string, args ...
 		args,
 	})
 
-	go t.withClient(relay.ConnectionID, func(c longPollConnection) {
+	go t.withClient(cid, func(c longPollConnection) {
 		// force a timeout if we block on sending too long..
 		go func() {
 			<-time.After(time.Second * 30)

--- a/transport.go
+++ b/transport.go
@@ -3,5 +3,5 @@ package relayr
 // Transport represents a communication mechanism between
 // a Relay and a client.
 type Transport interface {
-	CallClientFunction(relay *Relay, fn string, args ...interface{})
+	CallClientFunction(relay *Relay, cid, fn string, args ...interface{})
 }

--- a/websocket-transport.go
+++ b/websocket-transport.go
@@ -59,7 +59,7 @@ func (c *webSocketTransport) listen() {
 	}
 }
 
-func (c *webSocketTransport) CallClientFunction(relay *Relay, fn string, args ...interface{}) {
+func (c *webSocketTransport) CallClientFunction(relay *Relay, cid, fn string, args ...interface{}) {
 	buff := &bytes.Buffer{}
 	encoder := json.NewEncoder(buff)
 
@@ -73,7 +73,7 @@ func (c *webSocketTransport) CallClientFunction(relay *Relay, fn string, args ..
 		args,
 	})
 
-	o := c.connections[relay.ConnectionID]
+	o := c.connections[cid]
 
 	if o != nil {
 		o.out <- buff.Bytes()
@@ -101,7 +101,7 @@ func (c *connection) read() {
 				fmt.Println("ERR:", err)
 			}
 		} else {
-			c.c.CallClientFunction(relay, m.Method, m.Arguments)
+			c.c.CallClientFunction(relay, c.id, m.Method, m.Arguments)
 		}
 	}
 	c.ws.Close()


### PR DESCRIPTION
Sometimes we need to share states between all clients,but in your code,everytime client calls a method,you create a new instance,so the instance can not inherit any histroy state.
I modify the code,so when register an pointer type, it will share an instance between all clients,so all clients share same states. I also add a simple demo to show this.
My code is ugly,you can see it as an reference only.
